### PR TITLE
Move tsup to dev dependencies to prevent unnecessary deps in production apps

### DIFF
--- a/packages/opentelemetry-sdk-workers/package.json
+++ b/packages/opentelemetry-sdk-workers/package.json
@@ -80,8 +80,7 @@
 		"@opentelemetry/resources": "^1.17.0",
 		"@opentelemetry/sdk-trace-base": "^1.17.0",
 		"@opentelemetry/semantic-conventions": "^1.17.0",
-		"protobufjs": "^7.2.1",
-		"tsup": "^7.2.0"
+		"protobufjs": "^7.2.1"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230115.0",
@@ -89,6 +88,7 @@
 		"diary": "^0.4.3",
 		"lodash-es": "^4.17.21",
 		"long": "^5.2.1",
-		"protobufjs-cli": "^1.1.1"
+		"protobufjs-cli": "^1.1.1",
+		"tsup": "^7.2.0"
 	}
 }


### PR DESCRIPTION
#### Changes

Update tsup to be a dev-only dependency so it's not included in production apps using Highlight SDKs.

I can't say for certain whether or not tsup is a required dep for this package, but issues were disabled on the repo to ask and thought this was the best bet to help.
#### Issue

I'm having some issues with production builds on Vercel due to post-install steps for esbuild and dove in deeper to find out why it was being installed under production envs. Turns out that Highlight's dependency chain pulls in tsup and esbuild.

```sh
npm explain esbuild

esbuild@0.19.11
node_modules/esbuild
  peer esbuild@">=0.17" from bundle-require@4.0.2
  node_modules/bundle-require
    bundle-require@"^4.0.0" from tsup@7.3.0
    node_modules/tsup
      tsup@"^7.2.0" from @highlight-run/opentelemetry-sdk-workers@1.0.3
      node_modules/@highlight-run/opentelemetry-sdk-workers
        @highlight-run/opentelemetry-sdk-workers@"1.0.3" from @highlight-run/next@7.3.2
        node_modules/@highlight-run/next
          @highlight-run/next@"^7.3.2" from my-app@1.0.0
```

