### PR TITLE
Fix fetch type error

### DIFF
--- a/packages/opentelemetry-sdk-workers/src/sdk.ts
+++ b/packages/opentelemetry-sdk-workers/src/sdk.ts
@@ -268,7 +268,7 @@ export class WorkersSDK<TEnv extends Record<string, unknown> = {}> {
         this.ctx.waitUntil(this.end());
     }
 
-    private async _fetch(fetchTarget: Fetcher, request: Request | string, requestInitr?: RequestInit | Request): Promise<Response> {
+    private async _fetch(fetchTarget: { fetch: Fetcher['fetch'] }, request: Request | string, requestInitr?: RequestInit | Request): Promise<Response> {
         let downstreamRequest: Request;
         if (request instanceof Request) {
             downstreamRequest = cloneRequest(request);


### PR DESCRIPTION
Added this when I encountered a type error saying `_globalThis` didn't fulfill the requirements for `Fetcher` because it didn't have `connect`. I think the only thing we need on `_globalThis` is the `fetch` method, so I narrowed the types to get around that error.