### PR TITLE
Enable attribute spreading across spans

### DIFF
--- a/packages/opentelemetry-sdk-workers/src/exporters/OTLPCloudflareExporterBase.ts
+++ b/packages/opentelemetry-sdk-workers/src/exporters/OTLPCloudflareExporterBase.ts
@@ -37,6 +37,7 @@ export abstract class OTLPCloudflareExporterBase<
 	protected _sendingPromises: Promise<unknown>[] = [];
 	protected headers: Record<string, string>;
 	protected enableCompression: boolean;
+	protected attributes: Record<string, string>
 
 	public static parseEnv(env: Record<string, unknown>, exporterType: "LOGS" | "TRACES" | "METRICS") {
 		const headers = baggageUtils.parseKeyPairsIntoRecord(env[`OTEL_EXPORTER_OTLP_${exporterType}_HEADERS`] as string | undefined ?? env["OTEL_EXPORTER_OTLP_HEADERS"] as string | undefined ?? '');
@@ -75,7 +76,13 @@ export abstract class OTLPCloudflareExporterBase<
 		this.timeoutMillis = configureExporterTimeout(config.timeoutMillis);
 
 		this.enableCompression = config.compress ?? true;
+		this.attributes = {}
 	}
+
+	setAttributes(attributes: Record<string, string>) {
+		this.attributes = {...this.attributes, ...attributes};
+	}
+
 
 	/**
 	 * Export items.

--- a/packages/opentelemetry-sdk-workers/src/exporters/OTLPProtoTraceExporter.ts
+++ b/packages/opentelemetry-sdk-workers/src/exporters/OTLPProtoTraceExporter.ts
@@ -9,6 +9,7 @@ import {
 	OTLPCloudflareExporterBase,
 	OTLPCloudflareExporterBaseConfig,
 } from './OTLPCloudflareExporterBase'
+import { Resource } from '@opentelemetry/resources'
 
 const {
 	proto: {
@@ -42,6 +43,13 @@ export class OTLPProtoTraceExporter extends OTLPCloudflareExporterBase<
 	contentType = 'application/x-protobuf'
 
 	convert(spans: ReadableSpan[]): Uint8Array {
+		spans.forEach(span => {
+			const resource = span.resource.merge(new Resource(this.attributes))
+
+			// @ts-ignore
+			span.resource = resource
+		})
+
 		const convertedSpans = createExportTraceServiceRequest(spans, {
 			useHex: false,
 		})


### PR DESCRIPTION
By tracking `.attributes` at the class level, we can spread them across all outgoing spans and achieve better tracing.